### PR TITLE
fix: KPI-165 change key with id to avoid duplication of companies

### DIFF
--- a/src/views/ComparisonView/ComparisonView.jsx
+++ b/src/views/ComparisonView/ComparisonView.jsx
@@ -134,7 +134,7 @@ export function ComparisonView ({ companyComparison, peersComparison, isLoading,
                 <TableBody>
                   {validPeersComparison().map((row) => (
                     <TableRow
-                      key={row?.name}
+                      key={row?.id}
                       sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
                       <TableCell align="left">{row.name}</TableCell>
                       <TableCell align="left">{row.sector}</TableCell>


### PR DESCRIPTION
<!--- As a title use the format: [CODE] Jira Issue Title -->

## Jira Link

<!--- Jira link for an issue -->

[Go to Jira](https://kpinetwork.atlassian.net/browse/KPI-165)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Hotfix (Bug detected)
- [ ] Feature (Issue from an Active Sprint)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Unit Test.
- [ ] Coverage.

<!--- Only apply if you need explain details about your pull request -->

## Solution
We have a key for tablerows with company names, as we have right now some companies with the same name, it causes an error and cannot have the correct state, so the solution was to change the key with the correct value -> company id.
Please for the next user stories use always (when it's possible) id for keys.
[Here are more details about this issue](https://github.com/mbrn/material-table/issues/2478)