### PR TITLE
feat: KPI-279 update tags integration, move main hook to parent

### DIFF
--- a/src/components/Actions.jsx
+++ b/src/components/Actions.jsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles(theme => ({
   }
 }))
 
-export default function ButtonActions ({ okName, cancelName, onOk, onCancel, reverse = true }) {
+export default function ButtonActions ({ okName, cancelName, onOk, onCancel, allowActions = true, reverse = true }) {
   const classes = useStyles()
   return (
     <Box className={reverse ? classes.rowReverse : classes.row}>
@@ -32,12 +32,14 @@ export default function ButtonActions ({ okName, cancelName, onOk, onCancel, rev
         className={classes.mainButton}
         variant='contained'
         style={{ marginRight: reverse ? 0 : 20 }}
+        disabled={!allowActions}
        >
         {okName}
       </Button>
       <Button onClick={onCancel}
         className={classes.textButton}
         variant='outlined'
+        disabled={!allowActions}
       >
         {cancelName}
       </Button>

--- a/src/hooks/useTagsSections.jsx
+++ b/src/hooks/useTagsSections.jsx
@@ -23,8 +23,7 @@ const useTagsSection = () => {
       setCompaniesArray(result.companies)
       setCompanies(companyObject)
     } catch (_error) {
-      setCompaniesArray([])
-      setCompanies({})
+      setDefaultValues()
     }
   }
 

--- a/src/hooks/useTagsTable.jsx
+++ b/src/hooks/useTagsTable.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
-import { getTags } from '../service/tags'
+import { getTags, updateTags } from '../service/tags'
+import { ACTION_FAILED, UPDATE_ERROR } from '../utils/constants/tagsError'
 
 const useTagsTable = () => {
   const [total, setTotal] = useState(0)
@@ -9,6 +10,9 @@ const useTagsTable = () => {
   const [pageSize, setPageSize] = useState(100)
   const [page, setPage] = useState(0)
   const [maxPage, setMaxPage] = useState(0)
+  const [allowActions, setEnableActios] = useState(false)
+  const [data, setData] = useState({})
+  const [initialData, setInitialData] = useState({})
 
   useEffect(() => {
     initTags(pageSize, offset)
@@ -19,20 +23,26 @@ const useTagsTable = () => {
     setTags([])
     setTotal(0)
     setIsLoading(false)
+    setEnableActios(false)
+    setData({})
+    setInitialData({})
   }
 
   const initTags = async (limit, offset) => {
-    const response = await getAlltags({ limit, offset })
-    setTags(response)
+    await getAlltags({ limit, offset })
   }
 
   const getAlltags = async (options) => {
     try {
       setIsLoading(true)
+      setEnableActios(false)
       const result = await getTags(options)
       const { total, tags } = destructuring(result)
       setTags(tags)
+      setInitialData(copyTags(tags))
+      setData(copyTags(tags))
       setTotal(total)
+      setEnableActios(true)
       setIsLoading(false)
       return tags
     } catch (_error) {
@@ -68,12 +78,43 @@ const useTagsTable = () => {
     setTags([...tags, ...response])
   }
 
+  const copyTags = (tags) => {
+    return JSON.parse(JSON.stringify(
+      Object.fromEntries(
+        Object.values(tags).map(tag => [
+          tag.id, { ...tag, companies: tag.companies.map(company => company.id) }
+        ])
+      )
+    ))
+  }
+
+  const updateTagsInfo = async (body) => {
+    try {
+      setEnableActios(false)
+      const response = await updateTags({ tags: body })
+      if (response?.updated) {
+        initTags(pageSize, offset)
+        return null
+      }
+      return UPDATE_ERROR
+    } catch (_error) {
+      return ACTION_FAILED
+    } finally {
+      setEnableActios(true)
+    }
+  }
+
   return {
     total,
     tags,
     isLoading,
+    allowActions,
     pageSize,
     page,
+    data,
+    initialData,
+    setData,
+    updateTagsInfo,
     handleChangePage,
     handleChangePageSize
   }

--- a/src/service/tags.js
+++ b/src/service/tags.js
@@ -13,3 +13,12 @@ export const getTags = async (options) => {
   const data = await response.data
   return data
 }
+
+export const updateTags = async (body) => {
+  const headers = await getAuthorizationHeader()
+  const response = await axios.put(tagsUrl, body, {
+    headers: headers
+  })
+  const data = await response?.data
+  return data
+}

--- a/src/utils/constants/tagsError.js
+++ b/src/utils/constants/tagsError.js
@@ -1,0 +1,3 @@
+export const ACTION_FAILED = 'The application could not execute the action, please try again'
+export const UPDATE_ERROR = 'Tags could not be changed'
+export const NOTHING_TO_CHANGE = 'There is nothing to change'

--- a/src/views/TagsView/Components/TagsSectionView.jsx
+++ b/src/views/TagsView/Components/TagsSectionView.jsx
@@ -1,11 +1,15 @@
 import React, { useState } from 'react'
 import { Box, Button } from '@material-ui/core'
+import { Snackbar, Alert } from '@mui/material'
 import { makeStyles } from '@material-ui/core/styles'
 import { Add, DeleteOutlined, EditOutlined } from '@material-ui/icons'
 import { TagsForm } from './TagsForm'
 import { TagsTable } from './TagsTable'
 import ButtonActions from '../../../components/Actions'
 import useTagsSection from '../../../hooks/useTagsSections'
+import useTagsTable from '../../../hooks/useTagsTable'
+import { isEmptyObject } from '../../../utils/userFunctions'
+import { NOTHING_TO_CHANGE } from '../../../utils/constants/tagsError'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -23,32 +27,87 @@ const useStyles = makeStyles((theme) => ({
 
 export function TagsSectionView () {
   const classes = useStyles()
-  const isLoading = false
   const [openAdd, setOpenAdd] = useState(false)
   const [openDelete, setOpenDelete] = useState(false)
   const [openEdit, setOpenEdit] = useState(false)
   const [tag, setTag] = useState({})
-  const { companies, companiesArray } = useTagsSection()
+  const [errorMessage, setErrorMessage] = useState(null)
+  const {
+    companies,
+    companiesArray
+  } = useTagsSection()
+  const {
+    total,
+    tags,
+    isLoading,
+    allowActions,
+    pageSize,
+    page,
+    data,
+    initialData,
+    setData,
+    updateTagsInfo,
+    handleChangePage,
+    handleChangePageSize
+  } = useTagsTable()
 
   const onChange = (event, type) => {
     setTag({ ...tag, [type]: event?.target?.value })
   }
 
+  const onCancelEdit = () => {
+    setData(JSON.parse(JSON.stringify(initialData)))
+    setOpenEdit(false)
+  }
+
+  const buildBody = () => {
+    return Object.keys(data).reduce((body, tagID) => {
+      const nameChanged = data[tagID].name !== initialData[tagID].name
+      const companiesToAdd = data[tagID].companies.filter(companyID => !initialData[tagID].companies.includes(companyID))
+      const companiesToDelete = initialData[tagID].companies.filter(companyID => !data[tagID].companies.includes(companyID))
+      if (!(nameChanged || companiesToAdd.length > 0 || companiesToDelete.length > 0)) { return body }
+      const tagData = { companies_to_add: companiesToAdd, companies_to_delete: companiesToDelete }
+      if (nameChanged) tagData.name = data[tagID].name
+      return { ...body, [tagID]: tagData }
+    }, {})
+  }
+
+  const onUpdate = async (_) => {
+    const body = buildBody()
+    if (isEmptyObject(body)) {
+      setErrorMessage(NOTHING_TO_CHANGE)
+      return
+    }
+    const message = await updateTagsInfo(body)
+    setErrorMessage(message)
+  }
+
+  const onCloseSnackbar = () => {
+    setErrorMessage(null)
+  }
+
   return (
         <Box className={classes.root}>
-            {openAdd &&
-              <TagsForm
-                tag={tag}
-                onChange={onChange}
-                companies={companiesArray}
-                onCancel={() => {
-                  setOpenAdd(false)
-                }}
-              />
-            }
+          <Snackbar open={errorMessage != null} autoHideDuration={6000}
+            onClose={onCloseSnackbar}
+            anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+          >
+            <Alert severity="error">{errorMessage}</Alert>
+          </Snackbar>
+          {openAdd &&
+            <TagsForm
+              tag={tag}
+              onChange={onChange}
+              companies={companiesArray}
+              onCancel={() => {
+                setOpenAdd(false)
+              }}
+            />
+          }
+          { allowActions &&
             <Box sx={{ flexDirection: 'row-reverse', display: 'flex' }}>
             {
-              !openDelete && !openAdd && !openEdit && !isLoading &&
+              !openDelete && !openAdd && !openEdit &&
                 <Button
                   startIcon={<DeleteOutlined />}
                   style={{ textTransform: 'none' }}
@@ -59,7 +118,7 @@ export function TagsSectionView () {
                 </Button>
             }
             {
-              !openAdd && !openDelete && !openEdit && !isLoading &&
+              !openAdd && !openDelete && !openEdit &&
                 <Button
                   startIcon={<EditOutlined />}
                   style={{ textTransform: 'none' }}
@@ -70,7 +129,7 @@ export function TagsSectionView () {
                 </Button>
             }
             {
-              !openAdd && !openDelete && !openEdit && !isLoading &&
+              !openAdd && !openDelete && !openEdit &&
                 <Button
                   startIcon={<Add />}
                   style={{ textTransform: 'none' }}
@@ -81,31 +140,45 @@ export function TagsSectionView () {
                 </Button>
             }
             </Box>
-            {
-              openEdit &&
-              <Box sx={{ marginBottom: 5 }}>
-                <ButtonActions
-                  okName='Save'
-                  cancelName='Cancel'
-                  onOk={(_) => setOpenEdit(true)}
-                  onCancel={(_) => setOpenEdit(false)}
-                  reverse={true}
-                />
-                </Box>
-            }
-            {
-              openDelete &&
-              <Box sx={{ marginBottom: 5 }}>
-                <ButtonActions
-                  okName='Save'
-                  cancelName='Cancel'
-                  onOk={(_) => setOpenDelete(true)}
-                  onCancel={(_) => setOpenDelete(false)}
-                  reverse={true}
-                />
-                </Box>
-            }
-            <TagsTable isEditable={openEdit} companies={companies}/>
+          }
+          {
+            openEdit &&
+            <Box sx={{ marginBottom: 5 }}>
+              <ButtonActions
+                okName='Save'
+                cancelName='Cancel'
+                onOk={(_) => onUpdate(_)}
+                onCancel={(_) => onCancelEdit()}
+                reverse={true}
+                allowActions={allowActions}
+              />
+            </Box>
+          }
+          {
+            openDelete &&
+            <Box sx={{ marginBottom: 5 }}>
+              <ButtonActions
+                okName='Save'
+                cancelName='Cancel'
+                onOk={(_) => setOpenDelete(true)}
+                onCancel={(_) => setOpenDelete(false)}
+                reverse={true}
+                allowActions={allowActions}
+              />
+            </Box>
+          }
+          <TagsTable
+            isEditable={openEdit}
+            companies={companies}
+            data={data}
+            total={total}
+            tags={tags}
+            isLoading={isLoading}
+            pageSize={pageSize}
+            page={page}
+            handleChangePage={handleChangePage}
+            handleChangePageSize={handleChangePageSize}
+          />
         </Box>
   )
 }

--- a/tests/components/Actions.test.jsx
+++ b/tests/components/Actions.test.jsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ButtonActions from '../../src/components/Actions'
+
+const defaultProps = {
+  okName: 'Save',
+  cancelName: 'Cancel',
+  onOk: jest.fn(),
+  onCancel: jest.fn()
+}
+
+const setUp = (props) => {
+  render(<ButtonActions {...defaultProps} {...props} />)
+}
+
+describe('<ButtonActions />', () => {
+  describe('actions', () => {
+    it('should call onSave function when click on ok button', async () => {
+      setUp()
+      const saveButton = screen.getByRole('button', { name: defaultProps.okName })
+
+      fireEvent.click(saveButton)
+
+      expect(saveButton).toBeInTheDocument()
+      expect(defaultProps.onOk).toHaveBeenCalled()
+    })
+
+    it('should call onCancel function when click on cancel button', async () => {
+      setUp()
+      const cancelButton = screen.getByRole('button', { name: defaultProps.cancelName })
+
+      fireEvent.click(cancelButton)
+
+      expect(cancelButton).toBeInTheDocument()
+      expect(defaultProps.onCancel).toHaveBeenCalled()
+    })
+  })
+
+  describe('disable', () => {
+    it('should not be clickable when button are disabled', async () => {
+      setUp({ allowActions: false })
+      const saveButton = screen.getByRole('button', { name: defaultProps.okName })
+      const cancelButton = screen.getByRole('button', { name: defaultProps.cancelName })
+
+      fireEvent.click(cancelButton)
+      fireEvent.click(saveButton)
+
+      expect(saveButton).toBeDisabled()
+      expect(cancelButton).toBeDisabled()
+      expect(defaultProps.onOk).not.toHaveBeenCalled()
+      expect(defaultProps.onCancel).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('style', () => {
+    it('should add marginRigth when flex direction is not reverse', async () => {
+      setUp({ reverse: false })
+      const saveButton = screen.getByRole('button', { name: defaultProps.okName })
+
+      expect(saveButton.style.marginRight).toBe('20px')
+    })
+  })
+})

--- a/tests/hooks/useTagsTable.test.jsx
+++ b/tests/hooks/useTagsTable.test.jsx
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks'
-import { getTags } from '../../src/service/tags'
+import { getTags, updateTags } from '../../src/service/tags'
 import useTagsTable from '../../src/hooks/useTagsTable'
+import { ACTION_FAILED, UPDATE_ERROR } from '../../src/utils/constants/tagsError'
 
 jest.mock('../../src/service/tags')
 
@@ -98,5 +99,57 @@ describe('useTagsTable', () => {
     })
 
     expect(hookResponse.result.current.pageSize).toEqual(25)
+  })
+
+  it('useTagsTable hook should call get tags when update tags is successful', async () => {
+    mockService(getTags, tags)
+    mockService(updateTags, { updated: true })
+    let hookResponse
+
+    await act(async () => {
+      hookResponse = renderHook(() => useTagsTable())
+    })
+    await act(async () => {
+      hookResponse.result.current.updateTagsInfo({})
+    })
+
+    expect(hookResponse.result.current.allowActions).toBeTruthy()
+    expect(getTags).toHaveBeenCalled()
+  })
+
+  it('useTagsTable hook should return error message when tag could not be updated', async () => {
+    mockService(getTags, tags)
+    mockService(updateTags, { updated: false })
+    let hookResponse
+    let updateResponse
+
+    await act(async () => {
+      hookResponse = renderHook(() => useTagsTable())
+    })
+    await act(async () => {
+      updateResponse = await hookResponse.result.current.updateTagsInfo({})
+    })
+
+    expect(hookResponse.result.current.allowActions).toBeTruthy()
+    expect(updateResponse).toBe(UPDATE_ERROR)
+    expect(updateTags).toHaveBeenCalled()
+  })
+
+  it('useTagsTable hook should return error message when update tags failed', async () => {
+    mockService(getTags, tags)
+    mockService(updateTags, 'error')
+    let hookResponse
+    let updateResponse
+
+    await act(async () => {
+      hookResponse = renderHook(() => useTagsTable())
+    })
+
+    await act(async () => {
+      updateResponse = await hookResponse.result.current.updateTagsInfo({})
+    })
+
+    expect(hookResponse.result.current.allowActions).toBeTruthy()
+    expect(updateResponse).toBe(ACTION_FAILED)
   })
 })

--- a/tests/keyEventCodes.js
+++ b/tests/keyEventCodes.js
@@ -1,0 +1,14 @@
+export const ESCAPE = {
+  key: 'Escape',
+  keyCode: 27
+}
+
+export const ARROW_DOWN = {
+  key: 'ArrowDown',
+  keyCode: 40
+
+}
+
+export const ENTER = {
+  key: 'Enter'
+}

--- a/tests/service/tags.test.js
+++ b/tests/service/tags.test.js
@@ -1,12 +1,16 @@
 import axios from 'axios'
 import { Auth } from 'aws-amplify'
-import { getTags } from '../../src/service/tags'
+import { getTags, updateTags } from '../../src/service/tags'
+const { VITE_HOST: baseUrl } = import.meta.env
 
 const tags = {
   total: 2,
   tags: [{ id: '1', name: 'Tag' }]
 }
-const { VITE_HOST: baseUrl } = import.meta.env
+
+const updateTagsResponse = {
+  updated: true
+}
 
 const tagsUrl = `${baseUrl}/tags`
 
@@ -25,6 +29,16 @@ describe('tags service', () => {
       await getTags({ limit: 10, offset: 10 })
 
       expect(axios.get).toHaveBeenCalledWith(`${tagsUrl}?limit=10&offset=10`, { headers: { Authorization: null, 'Content-Type': 'application/json' } })
+    })
+  })
+
+  describe('update tags', () => {
+    it('should return if the tags were updated', async () => {
+      axios.put.mockResolvedValueOnce(updateTagsResponse)
+      await updateTags({})
+
+      expect(axios.put).toHaveBeenCalledWith(tagsUrl, {},
+        { headers: { Authorization: null, 'Content-Type': 'application/json' } })
     })
   })
 })

--- a/tests/views/TagsView/Components/TagsForm.test.jsx
+++ b/tests/views/TagsView/Components/TagsForm.test.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { TagsForm } from '../../../../src/views/TagsView/Components/TagsForm'
+import { ARROW_DOWN, ENTER } from '../../../keyEventCodes'
 
 jest.spyOn(Auth, 'currentAuthenticatedUser').mockReturnValue({
   getAccessToken: () => ({
@@ -64,8 +65,8 @@ describe('<TagsForm />', () => {
 
       const autocomplete = screen.getByRole('combobox')
       fireEvent.change(autocomplete, { target: { value: 'Test Company' } })
-      fireEvent.keyDown(autocomplete, { key: 'ArrowDown' })
-      fireEvent.keyDown(autocomplete, { key: 'Enter' })
+      fireEvent.keyDown(autocomplete, ARROW_DOWN)
+      fireEvent.keyDown(autocomplete, ENTER)
 
       expect(defaultProps.onChange).toHaveBeenCalled()
     })

--- a/tests/views/TagsView/Components/TagsSectionView.test.jsx
+++ b/tests/views/TagsView/Components/TagsSectionView.test.jsx
@@ -5,6 +5,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { TagsSectionView } from '../../../../src/views/TagsView/Components/TagsSectionView'
 import useTagsSections from '../../../../src/hooks/useTagsSections'
 import useTagsTable from '../../../../src/hooks/useTagsTable'
+import { NOTHING_TO_CHANGE, UPDATE_ERROR } from '../../../../src/utils/constants/tagsError'
+import { ESCAPE } from '../../../keyEventCodes'
 
 jest.mock('../../../../src/hooks/useTagsSections')
 jest.mock('../../../../src/hooks/useTagsTable')
@@ -15,10 +17,24 @@ jest.spyOn(Auth, 'currentAuthenticatedUser').mockReturnValue({
   })
 })
 
+const tags = {
+  123: { id: 123, name: 'Tag Sample', companies: [] },
+  124: { id: 124, name: 'Fashion', companies: [] }
+}
+
 const tableHookResponse = {
-  total: 1,
+  total: 2,
   isLoading: false,
-  tags: [{ id: '123', name: 'Tag Sample', companies: [] }]
+  allowActions: true,
+  pageSize: 10,
+  page: 0,
+  tags: JSON.parse(JSON.stringify(Object.values(tags))),
+  data: JSON.parse(JSON.stringify(tags)),
+  initialData: JSON.parse(JSON.stringify(tags)),
+  setData: jest.fn(),
+  updateTagsInfo: jest.fn(),
+  errorMessage: null,
+  setErrorMessage: jest.fn()
 }
 
 const hookResponse = {
@@ -57,6 +73,7 @@ describe('<TagsSectionView />', () => {
 
   describe('actions', () => {
     it('Should open form when click on Add Tag button', async () => {
+      useTagsTable.mockImplementation(() => tableHookResponse)
       useTagsSections.mockImplementation(() => hookResponse)
       setUp()
 
@@ -68,6 +85,7 @@ describe('<TagsSectionView />', () => {
     })
 
     it('Should close form when click on Cancel', async () => {
+      useTagsTable.mockImplementation(() => tableHookResponse)
       useTagsSections.mockImplementation(() => hookResponse)
       setUp()
 
@@ -79,6 +97,7 @@ describe('<TagsSectionView />', () => {
     })
 
     it('Should enable edition when click on Edit Tags button', () => {
+      useTagsTable.mockImplementation(() => tableHookResponse)
       useTagsSections.mockImplementation(() => hookResponse)
       setUp()
 
@@ -88,6 +107,7 @@ describe('<TagsSectionView />', () => {
     })
 
     it('Should disable edition when click on cancel', () => {
+      useTagsTable.mockImplementation(() => tableHookResponse)
       useTagsSections.mockImplementation(() => hookResponse)
       setUp()
 
@@ -98,18 +118,36 @@ describe('<TagsSectionView />', () => {
       expect(cancelButton).not.toBeInTheDocument()
     })
 
-    it('Should edit data when click on save before click on Edit tags', () => {
+    it('Should open snackbar when save edited values click without changes', async () => {
+      tableHookResponse.updateTagsInfo.mockReturnValue(UPDATE_ERROR)
+      useTagsTable.mockImplementation(() => tableHookResponse)
       useTagsSections.mockImplementation(() => hookResponse)
       setUp()
 
       fireEvent.click(screen.getByRole('button', { name: 'Edit Tags' }))
-      const saveButton = screen.getByRole('button', { name: 'Save' })
-      fireEvent.click(saveButton)
+      fireEvent.doubleClick(screen.getByRole('cell', { name: 'Tag Sample' }))
+      await waitFor(() => fireEvent.click(screen.getByRole('button', { name: 'Save' })))
 
-      expect(saveButton).toBeInTheDocument()
+      expect(screen.getByRole('presentation')).toBeInTheDocument()
+      expect(screen.getByText(NOTHING_TO_CHANGE)).toBeInTheDocument()
+    })
+
+    it('Should close snackbar when click outside of the snackbar', async () => {
+      tableHookResponse.updateTagsInfo.mockReturnValue(UPDATE_ERROR)
+      useTagsTable.mockImplementation(() => tableHookResponse)
+      useTagsSections.mockImplementation(() => hookResponse)
+      setUp()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Edit Tags' }))
+      fireEvent.doubleClick(screen.getByRole('cell', { name: 'Tag Sample' }))
+      await waitFor(() => fireEvent.click(screen.getByRole('button', { name: 'Save' })))
+      await waitFor(() => fireEvent.keyDown(screen.getByRole('presentation'), ESCAPE))
+
+      expect(screen.getByRole('presentation')).not.toHaveFocus()
     })
 
     it('Should enable deletion when click on Delete Tags button', () => {
+      useTagsTable.mockImplementation(() => tableHookResponse)
       useTagsSections.mockImplementation(() => hookResponse)
       setUp()
 
@@ -122,6 +160,7 @@ describe('<TagsSectionView />', () => {
     })
 
     it('Should disable deletion when click on Cancel', () => {
+      useTagsTable.mockImplementation(() => tableHookResponse)
       useTagsSections.mockImplementation(() => hookResponse)
       setUp()
 
@@ -133,6 +172,7 @@ describe('<TagsSectionView />', () => {
     })
 
     it('Should delete tags when click on Save', () => {
+      useTagsTable.mockImplementation(() => tableHookResponse)
       useTagsSections.mockImplementation(() => hookResponse)
       setUp()
 
@@ -141,6 +181,22 @@ describe('<TagsSectionView />', () => {
       fireEvent.click(saveButton)
 
       expect(saveButton).toBeInTheDocument()
+    })
+  })
+
+  describe('update tags', () => {
+    it('Should call updateTagsInfo when click on Save and tag changed', async () => {
+      useTagsTable.mockImplementation(() => tableHookResponse)
+      useTagsSections.mockImplementation(() => hookResponse)
+      setUp()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Edit Tags' }))
+      fireEvent.doubleClick(screen.getByRole('cell', { name: 'Tag Sample' }))
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Science' } })
+      await waitFor(() => fireEvent.click(screen.getByRole('cell', { name: 'Fashion' })))
+      await waitFor(() => fireEvent.click(screen.getByRole('button', { name: 'Save' })))
+
+      expect(tableHookResponse.updateTagsInfo).toHaveBeenCalled()
     })
   })
 })

--- a/tests/views/TagsView/Components/TagsTable.test.jsx
+++ b/tests/views/TagsView/Components/TagsTable.test.jsx
@@ -1,11 +1,40 @@
 import { Auth } from 'aws-amplify'
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { TagsTable } from '../../../../src/views/TagsView/Components/TagsTable'
-import useTagsTable from '../../../../src/hooks/useTagsTable'
 
-jest.mock('../../../../src/hooks/useTagsTable')
+const defaultProps = {
+  isEditable: false,
+  companies: {
+    1: 'E. CORP',
+    2: 'Sample Company',
+    3: 'Test Inc.'
+  },
+  data: {
+    1: {
+      id: 1,
+      name: 'Education',
+      companies: [1]
+    },
+    2: {
+      id: 2,
+      name: 'Technology',
+      companies: []
+    },
+    3: {
+      id: 3,
+      name: 'Fashion',
+      companies: [2]
+    }
+  },
+  total: 3,
+  isLoading: false,
+  pageSize: 10,
+  page: 0,
+  handleChangePage: jest.fn(),
+  handleChangePageSize: jest.fn()
+}
 
 jest.spyOn(Auth, 'currentAuthenticatedUser').mockReturnValue({
   getAccessToken: () => ({
@@ -13,27 +42,18 @@ jest.spyOn(Auth, 'currentAuthenticatedUser').mockReturnValue({
   })
 })
 
-const defaultProps = {
-  isEditable: false
-}
-
 const setUp = (props) => {
   render(
       <TagsTable {...defaultProps} {...props}/>
   )
 }
 
-const hookResponse = {
-  isLoading: false,
-  total: 1,
-  tags: [{ id: '123', name: 'Tag Sample', companies: [] }]
-}
-
 describe('<TagsTable />', () => {
   describe('render', () => {
     it('Should render tags Table', () => {
-      useTagsTable.mockImplementation(() => hookResponse)
-      setUp()
+      const data = JSON.parse(JSON.stringify(defaultProps.data))
+      data[2].companies = null
+      setUp({ data })
 
       const table = screen.getByRole('grid')
       const tagHeader = screen.getByText('Tag')
@@ -45,25 +65,62 @@ describe('<TagsTable />', () => {
     })
 
     it('Should render loading bar when data is loading', () => {
-      const response = { ...hookResponse, isLoading: true }
-      useTagsTable.mockImplementation(() => response)
-      setUp()
+      setUp({ isLoading: true })
 
       const loadingBar = screen.getByTestId('loading-progress')
 
       expect(loadingBar).toBeInTheDocument()
     })
+  })
 
-    it('Should enable edition on table when table is editable', () => {
-      useTagsTable.mockImplementation(() => hookResponse)
-      setUp()
-      const table = screen.getByRole('grid')
-      const tagHeader = screen.getByText('Tag')
-      const companiesHeader = screen.getByText('Companies')
+  describe('edition', () => {
+    it('Should change tag name on edition name texfield when table is editable', async () => {
+      setUp({ isEditable: true })
+      const tag = screen.getByRole('cell', { name: 'Education' })
 
-      expect(table).toBeInTheDocument()
-      expect(tagHeader).toBeInTheDocument()
-      expect(companiesHeader).toBeInTheDocument()
+      fireEvent.doubleClick(tag)
+      const inputCell = screen.getByRole('textbox')
+      fireEvent.change(inputCell, { target: { value: 'Science' } })
+      await waitFor(() => fireEvent.click(screen.getByRole('cell', { name: 'Fashion' })))
+
+      expect(inputCell.value).toBe('Science')
+    })
+
+    it('Should change tag companies on edition companies select when table is editable', async () => {
+      setUp({ isEditable: true })
+      const companyToSelect = 'Sample Company'
+      const companyAlreadySelected = 'E. CORP'
+
+      fireEvent.doubleClick(screen.getByRole('cell', { name: companyAlreadySelected }))
+      fireEvent.mouseDown(screen.getByRole('button', { name: companyAlreadySelected }))
+      fireEvent.click(screen.getByRole('option', { name: companyToSelect }))
+      await waitFor(() => fireEvent.click(screen.getByText('Fashion')))
+
+      expect(
+        screen.getByRole('cell',
+          { name: `${companyAlreadySelected},${companyToSelect}` })
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('pagination', () => {
+    it('Should call handleChangePage when click on change page', async () => {
+      setUp({ total: 20 })
+      const buttonNextPage = screen.getByRole('button', { name: 'Go to next page' })
+
+      fireEvent.click(buttonNextPage)
+
+      expect(defaultProps.handleChangePage).toHaveBeenCalled()
+    })
+
+    it('Should call handleChangePageSize when click on change page size', async () => {
+      setUp({ total: 20 })
+      const buttonPageSize = screen.getByRole('button', { name: 'Rows per page: 10' })
+
+      fireEvent.mouseDown(buttonPageSize)
+      fireEvent.click(screen.getByRole('option', { name: '50' }))
+
+      expect(defaultProps.handleChangePageSize).toHaveBeenCalled()
     })
   })
 })

--- a/tests/views/TagsView/TagsView.test.jsx
+++ b/tests/views/TagsView/TagsView.test.jsx
@@ -15,10 +15,20 @@ jest.spyOn(Auth, 'currentAuthenticatedUser').mockReturnValue({
   })
 })
 
+const tags = { 123: { id: '123', name: 'Tag Sample', companies: [] } }
 const tableHookResponse = {
   total: 1,
   isLoading: false,
-  tags: [{ id: '123', name: 'Tag Sample', companies: [] }]
+  tags: Object.values(tags),
+  allowActions: true,
+  pageSize: 10,
+  page: 0,
+  data: JSON.parse(JSON.stringify(tags)),
+  initialData: JSON.parse(JSON.stringify(tags)),
+  setData: jest.fn(),
+  updateTagsInfo: jest.fn(),
+  errorMessage: null,
+  setErrorMessage: jest.fn()
 }
 
 const hookResponse = {


### PR DESCRIPTION
<!--- As a title use the format: [CODE] Jira Issue Title -->

## Jira Link

<!--- Jira link for an issue -->

[Go to Jira](https://kpinetwork.atlassian.net/browse/KPI-279)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hotfix (Bug detected)
- [x] Feature (Issue from an Active Sprint)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Unit Test.
- [x] Coverage.

<!--- Only apply if you need to explain details about your pull request -->

## Solution
useTagsTable hook call was moved to TagsSectionView in order to update correctly when data was updated successfully.
Unit tests for pagination were added, and the other tests have been changed with the new functionality.
The structure for the Datagrid rows was modified to update with less complexity the source data.